### PR TITLE
[BUGFIX] Init Data 캐시 이슈 처리

### DIFF
--- a/backend/src/main/java/com/dajava/backend/domain/register/controller/RegisterController.java
+++ b/backend/src/main/java/com/dajava/backend/domain/register/controller/RegisterController.java
@@ -1,5 +1,7 @@
 package com.dajava.backend.domain.register.controller;
 
+import java.util.Set;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -172,5 +174,17 @@ public class RegisterController {
 		@ModelAttribute PageCaptureRequest request
 	) {
 		return registerService.createPageCapture(request);
+	}
+
+	private final RegisterCacheService registerCacheService;
+
+
+	@Operation(
+		summary = "솔루션 시리얼넘버의 캐시 정보를 반환하는 테스트 API"
+	)
+	@GetMapping(value = "/v1/register/test/cacheList")
+	@ResponseStatus(HttpStatus.OK)
+	public Set<String> getCacheList() {
+		return registerCacheService.getSerialNumberCache();
 	}
 }

--- a/backend/src/main/java/com/dajava/backend/global/initdata/InitData.java
+++ b/backend/src/main/java/com/dajava/backend/global/initdata/InitData.java
@@ -27,6 +27,7 @@ import com.dajava.backend.domain.event.es.repository.SolutionEventDocumentReposi
 import com.dajava.backend.domain.register.dto.register.RegisterCreateRequest;
 import com.dajava.backend.domain.register.entity.Register;
 import com.dajava.backend.domain.register.repository.RegisterRepository;
+import com.dajava.backend.domain.register.service.RegisterCacheService;
 import com.dajava.backend.global.utils.PasswordUtils;
 import com.dajava.backend.global.utils.TimeUtils;
 
@@ -47,6 +48,7 @@ public class InitData {
 	private final RegisterRepository registerRepository;
 	private final SessionDataDocumentRepository sessionDataDocumentRepository;
 	private final SolutionEventDocumentRepository solutionEventDocumentRepository;
+	private final RegisterCacheService registerCacheService;
 
 	private PointerClickEventDocument createEvent(Long time, int clientX, int clientY, String tag) {
 		return PointerClickEventDocument.builder()
@@ -141,6 +143,7 @@ public class InitData {
 
 		if (registerRepository.findBySerialNumber(register.getSerialNumber()).isEmpty()) {
 			Register newRegister = registerRepository.save(register);
+			registerCacheService.refreshCacheAll();
 			log.info("baseInit register 등록 완료");
 		}
 	}
@@ -241,7 +244,7 @@ public class InitData {
 				"AiSolutionTestSessionNumber",
 				"/home",
 				"click",               // 이벤트 타입: click, scroll, move 등
-				120,                   // scrollY
+			120,                   		// scrollY
 				2200,                  // scrollHeight
 				900,                   // viewportHeight
 				1280,                  // browserWidth

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -11,6 +11,8 @@ spring:
     username: lldj
     password: ${db.password}
     driver-class-name: com.mysql.cj.jdbc.Driver
+  cache:
+    type: redis
   jpa:
     hibernate:
       ddl-auto: update # 테스트 시에 새롭게 나오도록 수정
@@ -21,16 +23,17 @@ spring:
         format_sql: true
         highlight_sql: true
         use_sql_comments: true
+  data:
+    redis:
+      host: redis_1
+      port: 6379
+      password: 1234
 
 springdoc:
   swagger-ui:
     urls:
       - name: production
         url: https://dajava.pg.chsan626.co.kr/swagger-ui/index.html
-  data:
-    redis:
-      host: ${SPRING_REDIS_HOST:localhost}
-      port: ${SPRING_REDIS_PORT:6379}
 gemini:
   api:
     key: ${DAJAVA_AI_API_KEY}


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝 Part

- [ ] BE
- [ ] FE
- [ ] Infra
- [ ] Docs
- [ ] Test

<br/>

## 🔎 작업 내용
- InitData가 시리얼 넘버 Cache에 올라가지 않으면서 유효하지 않는 시리얼 넘버로 인식되는 문제를 해결

## 📈 이미지 첨부 (필요시)
- 관련 글 : https://www.notion.so/1d14873f28dd80308d2ef3836cccc77b?pvs=4