### PR TITLE
[FEAT] Register 만료 스케줄러 기능 및 테스트 API 추가

### DIFF
--- a/backend/src/main/java/com/dajava/backend/domain/register/RegisterInfo.java
+++ b/backend/src/main/java/com/dajava/backend/domain/register/RegisterInfo.java
@@ -2,6 +2,8 @@ package com.dajava.backend.domain.register;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,9 +17,16 @@ public class RegisterInfo {
 	private String serialNumber;
 	private String email;
 	private String url;
+
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
 	private LocalDateTime solutionDate;
+
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
 	private LocalDateTime solutionStartDate;
+
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
 	private LocalDateTime solutionEndDate;
+	
 	private boolean isCompleted;
 	private String eventState;
 }

--- a/backend/src/main/java/com/dajava/backend/domain/register/controller/RegisterController.java
+++ b/backend/src/main/java/com/dajava/backend/domain/register/controller/RegisterController.java
@@ -187,4 +187,15 @@ public class RegisterController {
 	public Set<String> getCacheList() {
 		return registerCacheService.getSerialNumberCache();
 	}
+
+	@Operation(
+		summary = "솔루션 시리얼넘버의 캐시 정보를 반환하는 테스트 API"
+	)
+	@GetMapping(value = "/v1/register/test/expire/{serialNumber}")
+	@ResponseStatus(HttpStatus.OK)
+	public void expireRegister(
+		@PathVariable String serialNumber
+	) {
+		registerService.expireRegister(serialNumber);
+	}
 }

--- a/backend/src/main/java/com/dajava/backend/domain/register/entity/Register.java
+++ b/backend/src/main/java/com/dajava/backend/domain/register/entity/Register.java
@@ -111,6 +111,10 @@ public class Register extends BaseTimeEntity {
 		this.endDate = newEndDate;
 	}
 
+	public void expire(){
+		this.isServiceExpired = true;
+	}
+
 	/**
 	 * 서비스 제공 기간이 지난 AI Solution 정보를 지웁니다.
 	 */

--- a/backend/src/main/java/com/dajava/backend/domain/register/repository/RegisterRepository.java
+++ b/backend/src/main/java/com/dajava/backend/domain/register/repository/RegisterRepository.java
@@ -74,6 +74,7 @@ public interface RegisterRepository extends JpaRepository<Register, Long> {
 		    AND r.modifiedDate < :deleteTime
 		""")
 	int deleteCleanupTargetRegisters(@Param("deleteTime") LocalDateTime deleteTime);
+
 	/**
 	 * 엔티티가 현재 시각 기준으로 14일 이상 수정 시각이 차이나는 Register 의 List를 조회후 반환
 	 * @param threshold 시간 비교를 위한 LocalDateTime 값 (서비스 정책상 14일 이전 데이터)
@@ -86,6 +87,19 @@ public interface RegisterRepository extends JpaRepository<Register, Long> {
 			AND r.isSolutionComplete = true
 		""")
 	List<Register> findAllCompletedRegisterList(LocalDateTime threshold);
+
+	/**
+	 * 수집 종료시간(endDate)가 이미 지났고, 아직 만료시키지 않은 Register를 조회한다.
+	 * @param now 현재 시간
+	 * @return List<Register>
+	 */
+	@Query("""
+			SELECT r
+			FROM Register r
+			WHERE r.endDate < :now
+			AND r.isServiceExpired = false
+		""")
+	List<Register> findExpiredTarget(LocalDateTime now);
 }
 
 

--- a/backend/src/main/java/com/dajava/backend/domain/register/scheduler/RegisterExpireScheduler.java
+++ b/backend/src/main/java/com/dajava/backend/domain/register/scheduler/RegisterExpireScheduler.java
@@ -1,0 +1,29 @@
+package com.dajava.backend.domain.register.scheduler;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.dajava.backend.domain.register.entity.Register;
+import com.dajava.backend.domain.register.repository.RegisterRepository;
+import com.dajava.backend.domain.register.service.RegisterService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RegisterExpireScheduler {
+
+	private final RegisterRepository registerRepository;
+
+	@Scheduled(cron = "0 0 0 * * *")
+	public void registerExpire() {
+
+		// 만료 대상 Register를 조회하여 처리한다.
+		registerRepository.findExpiredTarget(LocalDateTime.now()).forEach(Register::expire);
+	}
+}

--- a/backend/src/main/java/com/dajava/backend/domain/register/scheduler/RegisterExpireScheduler.java
+++ b/backend/src/main/java/com/dajava/backend/domain/register/scheduler/RegisterExpireScheduler.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.dajava.backend.domain.register.entity.Register;
 import com.dajava.backend.domain.register.repository.RegisterRepository;
@@ -21,8 +22,8 @@ public class RegisterExpireScheduler {
 	private final RegisterRepository registerRepository;
 
 	@Scheduled(cron = "0 0 0 * * *")
+	@Transactional
 	public void registerExpire() {
-
 		// 만료 대상 Register를 조회하여 처리한다.
 		registerRepository.findExpiredTarget(LocalDateTime.now()).forEach(Register::expire);
 	}

--- a/backend/src/main/java/com/dajava/backend/domain/register/service/RegisterService.java
+++ b/backend/src/main/java/com/dajava/backend/domain/register/service/RegisterService.java
@@ -183,4 +183,17 @@ public class RegisterService {
 			fileName
 		);
 	}
+
+	/**
+	 * 솔루션 시리얼 번호를 통해 조회된 Register의 이벤트 수집 기간을 강제로 만료한다.
+	 * @param serialNumber 시리얼 번호
+	 */
+	@Transactional
+	public void expireRegister(String serialNumber) {
+		Register register = registerRepository.findBySerialNumber(serialNumber).orElseThrow(
+			() -> new RegisterException(ErrorCode.REGISTER_NOT_FOUND));
+
+		log.info("Register 강제 만료, serialNumber : {}", serialNumber);
+		register.expire();
+	}
 }


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝 Part

- [ ] BE
- [ ] FE
- [ ] Infra
- [ ] Docs
- [ ] Test

<br/>

## 🔎 작업 내용
- 스케줄러를 통해 일정 시간마다 endDate가 지난 Register를 만료시킵니다.
- Register를 강제로 수집 기간 만료를 시키는 API를 추가하였습니다.