### PR TITLE
[REFACTOR] : 히트맵 반환 로직 수정

### DIFF
--- a/backend/src/main/java/com/dajava/backend/domain/heatmap/service/HeatmapServiceImpl.java
+++ b/backend/src/main/java/com/dajava/backend/domain/heatmap/service/HeatmapServiceImpl.java
@@ -70,10 +70,6 @@ public class HeatmapServiceImpl implements HeatmapService {
 			sortByTimestamp = true;
 		}
 
-		// 이미지가 존재하지 않으면 기본 너비, 높이 설정
-		int pageWidth = 1024;
-		int pageHeight = 1024;
-
 		try {
 			Register findRegister = registerRepository.findBySerialNumber(serialNumber)
 				.orElseThrow(() -> new HeatmapException(SOLUTION_SERIAL_NUMBER_INVALID));
@@ -129,8 +125,8 @@ public class HeatmapServiceImpl implements HeatmapService {
 
 				// 이미지의 높이, 너비를 BufferedImage 로 변환후 획득
 				ImageDimensions imageDimensions = fileStorageService.getImageDimensions(captureFileName);
-				pageWidth = imageDimensions.pageWidth();
-				pageHeight = imageDimensions.pageHeight();
+				int pageWidth = imageDimensions.pageWidth();
+				int pageHeight = imageDimensions.pageHeight();
 
 				response = response.toBuilder()
 					.gridSize(GRID_SIZE)
@@ -141,7 +137,11 @@ public class HeatmapServiceImpl implements HeatmapService {
 					.pageHeight(pageHeight)
 					.build();
 			} else {
-				throw new HeatmapException(PAGE_CAPTURE_NOT_FOUND);
+				// 이미지가 없어도 각 히트맵 생성 로직에서 각 그리드 사이즈, 페이지 너비 및 높이를 로그를 통해 생성해 반환함
+				response = response.toBuilder()
+					.gridSize(GRID_SIZE)
+					.pageCapture("") // 이미지가 없다면 빈 값 반환
+					.build();
 			}
 
 			// 소요 시간 측정
@@ -347,6 +347,10 @@ public class HeatmapServiceImpl implements HeatmapService {
 
 		// Heatmap Response 생성
 		return HeatmapResponse.builder()
+			.gridSizeX(maxPageWidth / GRID_SIZE)
+			.gridSizeY(maxPageHeight / GRID_SIZE)
+			.pageWidth(maxPageWidth)
+			.pageHeight(maxPageHeight)
 			.gridCells(gridCells)
 			.metadata(metadata)
 			.build();
@@ -483,6 +487,10 @@ public class HeatmapServiceImpl implements HeatmapService {
 
 		// Heatmap Response 생성
 		return HeatmapResponse.builder()
+			.gridSizeX(maxPageWidth / GRID_SIZE)
+			.gridSizeY(maxPageHeight / GRID_SIZE)
+			.pageWidth(maxPageWidth)
+			.pageHeight(maxPageHeight)
 			.gridCells(gridCells)
 			.metadata(metadata)
 			.build();

--- a/backend/src/main/java/com/dajava/backend/domain/heatmap/service/HeatmapServiceImpl.java
+++ b/backend/src/main/java/com/dajava/backend/domain/heatmap/service/HeatmapServiceImpl.java
@@ -69,6 +69,11 @@ public class HeatmapServiceImpl implements HeatmapService {
 		if (type.equals("scroll")) {
 			sortByTimestamp = true;
 		}
+
+		// 이미지가 존재하지 않으면 기본 너비, 높이 설정
+		int pageWidth = 1024;
+		int pageHeight = 1024;
+
 		try {
 			Register findRegister = registerRepository.findBySerialNumber(serialNumber)
 				.orElseThrow(() -> new HeatmapException(SOLUTION_SERIAL_NUMBER_INVALID));
@@ -124,8 +129,8 @@ public class HeatmapServiceImpl implements HeatmapService {
 
 				// 이미지의 높이, 너비를 BufferedImage 로 변환후 획득
 				ImageDimensions imageDimensions = fileStorageService.getImageDimensions(captureFileName);
-				int pageWidth = imageDimensions.pageWidth();
-				int pageHeight = imageDimensions.pageHeight();
+				pageWidth = imageDimensions.pageWidth();
+				pageHeight = imageDimensions.pageHeight();
 
 				response = response.toBuilder()
 					.gridSize(GRID_SIZE)

--- a/backend/src/main/java/com/dajava/backend/domain/heatmap/service/HeatmapServiceImpl.java
+++ b/backend/src/main/java/com/dajava/backend/domain/heatmap/service/HeatmapServiceImpl.java
@@ -128,19 +128,27 @@ public class HeatmapServiceImpl implements HeatmapService {
 				int pageWidth = imageDimensions.pageWidth();
 				int pageHeight = imageDimensions.pageHeight();
 
-				response = response.toBuilder()
-					.gridSize(GRID_SIZE)
-					.gridSizeX(pageWidth / GRID_SIZE)
-					.gridSizeY(pageHeight / GRID_SIZE)
-					.pageCapture(captureFileName)
-					.pageWidth(pageWidth)
-					.pageHeight(pageHeight)
-					.build();
+				if (pageWidth == 0 && pageHeight == 0) {
+					// 이미지가 알 수 없는 이유로 손상된 경우 이벤트 기반 페이지 너비, 높이, 그리드 사이즈 그대로 사용
+					response = response.toBuilder()
+						.gridSize(GRID_SIZE)
+						.pageCapture("")
+						.build();
+				} else {
+					response = response.toBuilder()
+						.gridSize(GRID_SIZE)
+						.gridSizeX(pageWidth / GRID_SIZE)
+						.gridSizeY(pageHeight / GRID_SIZE)
+						.pageCapture(captureFileName)
+						.pageWidth(pageWidth)
+						.pageHeight(pageHeight)
+						.build();
+				}
 			} else {
-				// 이미지가 없어도 각 히트맵 생성 로직에서 각 그리드 사이즈, 페이지 너비 및 높이를 로그를 통해 생성해 반환함
+				// 이미지 관련 데이터가 없어도 반환된 데이터를 그대로 사용
 				response = response.toBuilder()
 					.gridSize(GRID_SIZE)
-					.pageCapture("") // 이미지가 없다면 빈 값 반환
+					.pageCapture("")
 					.build();
 			}
 

--- a/backend/src/main/java/com/dajava/backend/domain/image/service/pageCapture/FileStorageService.java
+++ b/backend/src/main/java/com/dajava/backend/domain/image/service/pageCapture/FileStorageService.java
@@ -158,18 +158,21 @@ public class FileStorageService {
 	 */
 	public ImageDimensions getImageDimensions(String fileName) {
 		try {
+			// width, height 기본값 설정
+			int width = 1024;
+			int height = 1024;
+
 			// 기존 getImage() 메서드 호출
 			Resource imageResource = getImage(fileName);
 
 			// 이미지 스트림을 BufferedImage 로 변환
 			BufferedImage image = ImageIO.read(imageResource.getInputStream());
-			if (image == null) {
-				throw new ImageException(ErrorCode.INVALID_IMAGE_FILE);
-			}
 
-			// 높이와 너비 추출
-			int width = image.getWidth();
-			int height = image.getHeight();
+			// 불러온 이미지에 이상이 없다면 높이와 너비 추출
+			if (image != null) {
+				width = image.getWidth();
+				height = image.getHeight();
+			}
 
 			return new ImageDimensions(width, height);
 		} catch (IOException e) {

--- a/backend/src/main/java/com/dajava/backend/domain/image/service/pageCapture/FileStorageService.java
+++ b/backend/src/main/java/com/dajava/backend/domain/image/service/pageCapture/FileStorageService.java
@@ -159,8 +159,8 @@ public class FileStorageService {
 	public ImageDimensions getImageDimensions(String fileName) {
 		try {
 			// 이미지 이상을 대비해 width, height 기본값 설정
-			int width = 1024;
-			int height = 1024;
+			int width = 0;
+			int height = 0;
 
 			// 기존 getImage() 메서드 호출
 			Resource imageResource = getImage(fileName);

--- a/backend/src/main/java/com/dajava/backend/domain/image/service/pageCapture/FileStorageService.java
+++ b/backend/src/main/java/com/dajava/backend/domain/image/service/pageCapture/FileStorageService.java
@@ -158,7 +158,7 @@ public class FileStorageService {
 	 */
 	public ImageDimensions getImageDimensions(String fileName) {
 		try {
-			// width, height 기본값 설정
+			// 이미지 이상을 대비해 width, height 기본값 설정
 			int width = 1024;
 			int height = 1024;
 

--- a/backend/src/main/java/com/dajava/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/dajava/backend/global/exception/ErrorCode.java
@@ -56,10 +56,7 @@ public enum ErrorCode {
 
 	// Image
 	INVALID_IMAGE_FILE(HttpStatus.BAD_REQUEST, "유효한 이미지 파일이 아닙니다."),
-	IMAGE_IO_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 읽기 중 오류가 발생했습니다."),
-
-	// Heatmap
-	PAGE_CAPTURE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지가 없어 히트맵을 불러올 수 없습니다.");
+	IMAGE_IO_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 읽기 중 오류가 발생했습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String description;


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝 Part

- [x] BE
- [ ] FE
- [ ] Infra
- [ ] Docs
- [ ] Test

<br/>


## 🔎 작업 내용

- 클릭, 이동, 스크롤 히트맵 생성 로직에서 너비, 높이, 그리드 사이즈를 설정해 반환
- 이미지가 손상되었거나, 관련 이미지 데이터가 없다면 SolutionEvent 기반으로 생성된 데이터를 그대로 사용
- 이미지가 정상적으로 너비, 높이를 반환한다면 해당값으로 바꿔서 반환

<br/>

